### PR TITLE
Fix/heading css override

### DIFF
--- a/public/widget.css
+++ b/public/widget.css
@@ -149,17 +149,17 @@
 
 
     .kis-widget.vertical {
-        width: 186px;
+        width: 190px;
         /* This has been removed because if one of the pages in the animation is */
         /* larger than the box it will overflow the box and the border will not */
         /* apear at the bottom any more */
-        /*height: 496px;*/
+        height: 500px;
         flex-direction: column;
     }
 
     .kis-widget.horizontal {
-        width: 611px;
-        height: 146px;
+        width: 615px;
+        height: 150px;
     }
 
     .kis-widget.vertical.responsive, .kis-widget.horizontal.responsive {

--- a/public/widget.css
+++ b/public/widget.css
@@ -133,7 +133,7 @@
 
     .kis-widget .kis-widget__lead .kis-widget__title {
         color: #308282;
-        font-size: 48px;
+        font-size: 48px!important;
         font-weight: normal;
         line-height: 57px;
         margin: 0;

--- a/public/widget.js
+++ b/public/widget.js
@@ -137,7 +137,7 @@ DiscoverUniWidget.prototype = {
 
     handleResponsive: function() {
         if (this.inIframe()) {
-            if (window.innerWidth > window.innerHeight) {
+            if (window.innerWidth > MINIMUM_RESPONSIVE_HORIZONTAL_WIDTH){
                 this.targetDiv.classList.add('horizontal');
             } else {
                 this.targetDiv.classList.add('vertical');


### PR DESCRIPTION
### What

- Override for provider stat % heading eg here: http://www.bristol.ac.uk/study/undergraduate/2021/english/ba-english/
- Increased the size of the widget in css to be in line with the new styles as per updated provider guidance.
- Added a minimum width for the responsive horizontal iframe widget. Requires discussion.

