### PR TITLE
changes to allow for aggregation levels

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -81,7 +81,7 @@ var CONTENT = {
     },
     'dataFor': {
         'en-gb': 'Data for ',
-        'cy-gb': 'Data ar gyfer: '
+        'cy-gb': 'Data ar gyfer '
     },
     'dataForAggregated': {
         'en-gb': 'Data for courses in ',

--- a/public/widget.js
+++ b/public/widget.js
@@ -80,7 +80,7 @@ var CONTENT = {
         'cy-gb': 'Blwyddyn dramor yn ddewisol'
     },
     'dataFor': {
-        'en-gb': 'Data for: ',
+        'en-gb': 'Data for ',
         'cy-gb': 'Data ar gyfer: '
     },
     'dataForAggregated': {
@@ -90,6 +90,10 @@ var CONTENT = {
     'at': {
         'en-gb': ' at ',
         'cy-gb': ' yn '
+    },
+    'overTwoYears': {
+        'en-gb': 'over two years',
+        'cy-gb': 'dros ddwy flynedd'
     }
 }
 
@@ -197,11 +201,10 @@ DiscoverUniWidget.prototype = {
     renderWidget: function(status, response) {
         if (status === 200) {
             var courseData = JSON.parse(response);
-
-            if (this.hasRequiredStats(courseData) && !this.isMultiSubject(courseData)) {
+            if (this.hasRequiredStats(courseData)) {
                 new DataWidget(this.targetDiv, courseData, this.language, this.languageKey, this.kismode,
-                                this.hasOverallSatisfactionStats, this.hasTeachingSatisfactionStats, this.hasWorkStats,
-                                this.generateLink.bind(this));
+                        this.hasOverallSatisfactionStats, this.hasTeachingSatisfactionStats, this.hasWorkStats,
+                        this.generateLink.bind(this));
             }
             else {
                 new NoDataWidget(this.targetDiv, courseData.course_name, courseData.institution_name, this.language,
@@ -211,10 +214,6 @@ DiscoverUniWidget.prototype = {
             new NoDataWidget(this.targetDiv, "", "", this.language, this.languageKey, this.kismode,
                                 this.generateLink.bind(this));
         }
-    },
-
-    isMultiSubject: function(courseData) {
-        return Boolean(courseData.statistics.nss.length > 1 || courseData.statistics.employment.length > 1);
     },
 
     setOverallSatisfactionStats: function(nssStats) {
@@ -289,7 +288,7 @@ DataWidget.prototype = {
         this.carousel();
     },
 
-    createSlideNode: function(idName, statNode, isNotAggregated) {
+    createSlideNode: function(idName, statNode, aggregation_level) {
         var slideNode = document.createElement('div');
         slideNode.classList.add('kis-widget__lead-slide', 'kis-widget__fade');
         slideNode.id = idName;
@@ -298,7 +297,7 @@ DataWidget.prototype = {
         slideNode.appendChild(slideSurroundNode);
 
         slideSurroundNode.appendChild(statNode);
-        slideSurroundNode.appendChild(this.renderCourseDetails(isNotAggregated));
+        slideSurroundNode.appendChild(this.renderCourseDetails(aggregation_level));
 
         return slideNode;
     },
@@ -330,48 +329,42 @@ DataWidget.prototype = {
     },
 
     renderSatisfactionSlide: function() {
-        var isNotAggregated = this.courseData.statistics.nss[0].aggregation_level === 14 ||
-                                this.courseData.statistics.nss[0].aggregation_level === 24
-
+        var aggregation_level = this.courseData.statistics.nss[0].aggregation_level;
         var percentage = this.courseData.statistics.nss[0].question_27.agree_or_strongly_agree + '%';
         var introText = CONTENT.satisfactionIntro[this.language];
 
         var statNode = this.createStatNode(this.createTitleNode(percentage), this.createIntroNode(introText));
 
-        var slideNode = this.createSlideNode('satisfaction', statNode, isNotAggregated);
+        var slideNode = this.createSlideNode('satisfaction', statNode, aggregation_level);
 
         return slideNode;
     },
 
     renderExplanationSlide: function() {
-        var isNotAggregated = this.courseData.statistics.nss[0].aggregation_level === 14 ||
-                                this.courseData.statistics.nss[0].aggregation_level === 24
-
+        var aggregation_level = this.courseData.statistics.nss[0].aggregation_level;
         var percentage = this.courseData.statistics.nss[0].question_1.agree_or_strongly_agree + '%';
         var introText = CONTENT.explanationIntro[this.language];
 
         var statNode = this.createStatNode(this.createTitleNode(percentage), this.createIntroNode(introText));
 
-        var slideNode = this.createSlideNode('explanation', statNode, isNotAggregated);
+        var slideNode = this.createSlideNode('explanation', statNode, aggregation_level);
 
         return slideNode;
     },
 
     renderWorkSlide: function() {
-        var isNotAggregated = this.courseData.statistics.employment[0].aggregation_level === 14 ||
-                                this.courseData.statistics.employment[0].aggregation_level === 24
-
+        var aggregation_level = this.courseData.statistics.employment[0].aggregation_level;
         var percentage = this.courseData.statistics.employment[0].in_work_or_study + '%';
         var introText = CONTENT.workIntro[this.language];
 
         var statNode = this.createStatNode(this.createTitleNode(percentage), this.createIntroNode(introText));
 
-        var slideNode = this.createSlideNode('work', statNode, isNotAggregated);
+        var slideNode = this.createSlideNode('work', statNode, aggregation_level);
 
         return slideNode;
     },
 
-    renderCourseDetails: function(isNotAggregated)  {
+    renderCourseDetails: function(aggregation_level)  {
         var courseDetailsNode = document.createElement('div');
         courseDetailsNode.classList.add('kis-widget__course-details');
 
@@ -382,11 +375,37 @@ DataWidget.prototype = {
         if (typeof courseName === 'undefined') {
             courseName = this.courseData.course_name['english'];
         }
-        if (isNotAggregated) {
+
+        this.kismode = this.kismode == "FullTime" ? "Full time" : "Part time";
+
+        if (aggregation_level == 14 ){
             courseName += this.courseData.honours_award_provision === 1 ? ' (Hons) ' : ' ';
-            courseName += this.courseData.title[this.languageKey]
             var dataFor = CONTENT.dataFor[this.language];
-            var course = document.createTextNode(dataFor + courseName);
+            var at = CONTENT.at[this.language];
+            var institution = this.courseData.institution_name[this.languageKey];
+            var course = document.createTextNode(dataFor + courseName + ' (' + this.kismode + ')' + at + institution);
+
+        } else if (aggregation_level == 24) {
+            courseName += this.courseData.honours_award_provision === 1 ? ' (Hons) ' : ' ';
+            var dataFor = CONTENT.dataFor[this.language];
+            var at = CONTENT.at[this.language];
+            var overTwoYears = CONTENT.overTwoYears[this.language];
+            var institution = this.courseData.institution_name[this.languageKey];
+            var course = document.createTextNode(dataFor + courseName + ' (' + this.kismode + ')' + at + institution + ', ' + overTwoYears);
+
+        } else if (aggregation_level == 21 || aggregation_level == 22 || aggregation_level == 23){
+            var dataForAggregated = CONTENT.dataForAggregated[this.language];
+            var at = CONTENT.at[this.language];
+            var institution = this.courseData.institution_name[this.languageKey];
+            var overTwoYears = CONTENT.overTwoYears[this.language];
+            var course = document.createTextNode(dataForAggregated + courseName + ' ' + overTwoYears + at + institution);
+
+        } else if (aggregation_level == 11 || aggregation_level == 12 || aggregation_level == 13){
+            var dataFor = CONTENT.dataForAggregated[this.language];
+            var at = CONTENT.at[this.language];
+            var institution = this.courseData.institution_name[this.languageKey];
+            var course = document.createTextNode(dataFor + courseName + at + institution);
+
         } else {
             var dataFor = CONTENT.dataForAggregated[this.language];
             var at = CONTENT.at[this.language];
@@ -397,23 +416,25 @@ DataWidget.prototype = {
 
         courseDetailsNode.appendChild(courseNode);
 
-        if (isNotAggregated) {
-            var featuresNode = document.createElement("p");
-            featuresNode.classList.add('kis-widget__course');
-            var featureList = [this.kismode];
-            var placementYear = this.courseData.sandwich_year.code;
-            featureList.push(placementYear === 1 ? CONTENT.placementOptional[this.language] :
-                                placementYear === 2 ? CONTENT.placement[this.language] : null)
-            var yearAbroad = this.courseData.sandwich_year.code;
-            featureList.push(yearAbroad === 1 ? CONTENT.abroadOptional[this.language] :
-                                yearAbroad === 2 ? CONTENT.abroad[this.language] : null)
-            var foundationYear = this.courseData.sandwich_year.code;
-            featureList.push(foundationYear === 1 ? CONTENT.foundationOptional[this.language] :
-                                foundationYear === 2 ? CONTENT.foundation[this.language] : null)
-            var features = document.createTextNode(featureList.filter(Boolean).join(', '));
-            featuresNode.appendChild(features);
+        if (aggregation_level == 14 || aggregation_level == 24) {
+            if (this.courseData.sandwich_year) {
+                var featuresNode = document.createElement("p");
+                featuresNode.classList.add('kis-widget__course');
+                var featureList = [this.kismode];
+                var placementYear = this.courseData.sandwich_year.code;
+                featureList.push(placementYear === 1 ? CONTENT.placementOptional[this.language] :
+                    placementYear === 2 ? CONTENT.placement[this.language] : null)
+                var yearAbroad = this.courseData.sandwich_year.code;
+                featureList.push(yearAbroad === 1 ? CONTENT.abroadOptional[this.language] :
+                                    yearAbroad === 2 ? CONTENT.abroad[this.language] : null)
+                var foundationYear = this.courseData.sandwich_year.code;
+                featureList.push(foundationYear === 1 ? CONTENT.foundationOptional[this.language] :
+                    foundationYear === 2 ? CONTENT.foundation[this.language] : null)
+                var features = document.createTextNode(featureList.filter(Boolean).join(', '));
+                featuresNode.appendChild(features);
 
-            courseDetailsNode.appendChild(featuresNode);
+                courseDetailsNode.appendChild(featuresNode);
+            }
         }
 
         return courseDetailsNode;

--- a/test.html
+++ b/test.html
@@ -6,38 +6,39 @@
 </head>
 
 <body style="background-color:#f5b649; min-height:2000px">
-    <!-- Manchester: (has two earnings numbers so won't show the statics. Look at Halo ticket 7199) -->
-    <h3>Missing Data Test (responsive)</h3>
-    <div style="min-width:190px;height:auto;" class="kis-widget" data-institution="10007798" data-course="106" data-kismode="FullTime" data-orientation="responsive" data-language="en-GB"></div>
     
     <!-- vertical test -->
-    <h3>Fixed vertical test</h3>
-    <div style="height: 500px; width: 190px;" class="kis-widget" data-institution="10007783" data-course="N400" data-kismode="FullTime" data-orientation="vertical" data-language="en-GB"></div>
+    <h3>Fixed vertical test (nss/empagg = 14)</h3>
+    <div style="width:190px; height:500px;" class="kis-widget" data-institution="10000291" data-course="K00005" data-kismode="FullTime" data-orientation="vertical" data-language="en-GB"></div>
+
+    <!-- vertical test -->
+    <h3>Fixed vertical test (nss/empagg = 21/22/23)</h3>
+    <div style="width:190px; height:500px;" class="kis-widget" data-institution="10000291" data-course="K00239" data-kismode="PartTime" data-orientation="vertical" data-language="en-GB"></div>
 
     <!-- horizontal test -->
-    <h3>Fixed horizontal test</h3>
-   <div style="height: 150px; width: 615px;" class="kis-widget" data-institution="10007814" data-course="UFBSACCA" data-kismode="FullTime" data-orientation="horizontal" data-language="en-GB"></div>
+    <h3>Fixed horizontal test (nss/empagg = 11/12/13)</h3>
+   <div style="width:615px; height:150px;" class="kis-widget" data-institution="10000291" data-course="K00032" data-kismode="FullTime" data-orientation="horizontal" data-language="en-GB"></div>
    
     <!-- responsive test -->
     <!-- minimum width for responsive item is 190 (height must be auto and not fixed) -->
-    <h3>Responsive test</h3>
-    <div style="min-width:190px;height:auto;" class="kis-widget" data-institution="10007783" data-course="N400" data-kismode="FullTime" data-orientation="responsive" data-language="en-GB"></div>
+    <h3>Responsive test (nss/empagg = 24)</h3>
+    <div style="min-width:190px;" class="kis-widget" data-institution="10000571" data-course="BA-BMHRM" data-kismode="FullTime" data-orientation="responsive" data-language="en-GB"></div>
   
 
     <h3>Responsive iframe test</h3>
     <iframe id="unistats-widget-frame" title="Unistats KIS Widget"
     src="http://localhost:8001/widget/10007855/BSHS4XSSCSCS/responsive/small/en-GB/FullTime"
-    scrolling="no" style="overflow: hidden; border: 0px none transparent; min-width: 194px; min-height: 155px;width:100%;"></iframe>
+    scrolling="no" style="overflow: hidden; border: 0px none transparent; min-width: 194px; min-height: 155px; width:100%;"></iframe>
 
     <h3>Fixed vertical iframe test</h3>
     <iframe id="unistats-widget-frame" title="Unistats KIS Widget"
     src="http://localhost:8001/widget/10007855/BSHS4XSSCSCS/vertical/small/en-GB/FullTime"
-    scrolling="no"style="overflow: hidden; border: 0px none transparent; width: 194px; height:500px;"></iframe>
+    scrolling="no" style="border: 0px none transparent; width: 198px; height:508px;"></iframe>
 
     <h3>Fixed horizontal iframe test</h3>
     <iframe id="unistats-widget-frame" title="Unistats KIS Widget"
     src="http://localhost:8001/widget/10007855/BSHS4XSSCSCS/horizontal/small/en-GB/FullTime"
-    scrolling="no"style="overflow: hidden; border: 0px none transparent; width: 619px; height:154px;"></iframe>
+    scrolling="no" style="border: 0px none transparent; width: 624px; height:158px;"></iframe>
 
     <script>
         (function (d) {


### PR DESCRIPTION
### What

Widget.js checks aggregation levels and changes course title/details line based on the level:

**1. Course level data (1 year) - NSSAGG / EMPAGG = 14**
Where the widget displays course level data for an item (i.e. NSSAGG/EMPAGG = 14) it should include the text:
“Data for <Name of course> (<KISMODE>) at <Provider>” (name of course is made up of KISAIMLABEL+HONOURS+TITLE)
_E.g. “Data for BA (Hons) Architecture (full time) at UWE Bristol”_

**2. Course level data (2 years) - NSSAGG / EMPAGG = 24**
Where the widget displays course level data for an item (i.e. NSSAGG/EMPAGG = 24) it should include the text:
“Data for <Name of course> (<KISMODE>) at <Provider>, over two years” (name of course is made up of KISAIMLABEL+HONOURS+TITLE)
_E.g. “Data for BA (Hons) Architecture (full time) at UWE Bristol, over two years”_

**3. Subject level data (1 year) - NSSAGG / EMPAGG = 11/12/13**
Where the widget displays data aggregated at subject level (1 year) (i.e. NSSAGG/EMPAGG = 11/12/13) is should include the text:
“Data for courses in <NSSSBJ/EMPSBJ> at <Provider>”
_E.g. “Data for courses in Accounting at The University of Bradford”_

**4. Subject level data (2 years) - NSSAGG / EMPAGG = 21/22/23**
Where the widget displays data aggregated at subject level (2 years) (i.e. NSSAGG/EMPAGG = 21/22/23) is should include the text: 
“Data for courses in <NSSSBJ/EMPSBJ> over two years at <Provider>”
_E.g. “Data for courses in Accounting over two years at The University of Bradford”_


### How to review

Load widget-server locally, follow readme to setup and run `make dev`. 
Open test.html in your browser to view example widgets.
